### PR TITLE
feat: handle single-type entity type

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -14,7 +14,7 @@ class Strapi extends Hookable {
 
     this.$cookies = ctx.app.$cookies
     this.$http = ctx.$http.create({})
-    this.$http.setToken(this.getToken (), 'Bearer')
+    this.$http.setToken(this.getToken(), 'Bearer')
     this.$http.setBaseURL(runtimeConfig.url || '<%= options.url %>')
     this.$http.onError((err) => {
       const { response: { data: { message: msg } } } = err
@@ -118,14 +118,21 @@ class Strapi extends Hookable {
   }
 
   update (entity, id, data) {
-    return this.$http.$put(`/${entity}/${id}`, data)
+    if (typeof id === 'object') {
+      data = id
+      id = undefined
+    }
+
+    const path = [entity, id].filter(Boolean).join('/')
+    return this.$http.$put(`/${path}`, data)
   }
 
   delete (entity, id) {
-    return this.$http.$delete(`/${entity}/${id}`)
+    const path = [entity, id].filter(Boolean).join('/')
+    return this.$http.$delete(`/${path}`)
   }
 
-  async graphql(data) {
+  async graphql (data) {
     const request = await this.$http.$post(`/graphql`, data)
     return request.data;
   }
@@ -147,14 +154,34 @@ class Strapi extends Hookable {
 
 export default async function (ctx, inject) {
   <%= JSON.stringify(options.entities) %>.forEach((entity) => {
-    const key = `$${entity}`
-    if (Strapi.prototype.hasOwnProperty(key)) {
-      return
-    }
-    Object.defineProperty(Strapi.prototype, key, {
-      get () {
-        const that = this
-        return {
+  let key
+  let type = 'collection'
+  if (typeof entity === 'object') {
+    key = `$${entity.name}`
+    type = entity.type || 'collection'
+    entity = entity.name
+  } else {
+    key = `$${entity}`
+  }
+  if (Strapi.prototype.hasOwnProperty(key)) {
+    return
+  }
+  Object.defineProperty(Strapi.prototype, key, {
+    get () {
+      const that = this
+      return ({
+        single: {
+          find (...args) {
+            return that.find(entity, ...args)
+          },
+          update (...args) {
+            return that.update(entity, ...args)
+          },
+          delete (...args) {
+            return that.delete(entity, ...args)
+          }
+        },
+        collection: {
           find (...args) {
             return that.find(entity, ...args)
           },
@@ -174,9 +201,10 @@ export default async function (ctx, inject) {
             return that.delete(entity, ...args)
           }
         }
-      }
-    })
+      })[type]
+    }
   })
+})
 
   const strapi = new Strapi(ctx)
 


### PR DESCRIPTION
Handle Single Type endpoints: https://strapi.io/documentation/v3.x/content-api/api-endpoints.html#endpoints

- `update` and `delete` methods now works without the `id`
- Entities can now be defined like: 

```js
entities: [
  'products',
  { name: 'articles', type: 'collection' },
  { name: 'homepage', type: 'single' }
]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)