### PR TITLE
fix(lib): don't erase user on logout

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -75,7 +75,6 @@ class Strapi extends Hookable {
   }
 
   logout () {
-    this.setUser(null)
     this.clearToken()
   }
 


### PR DESCRIPTION
Prevent `$strapi.logout()` to erase state `user` which breaks templates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)