### PR TITLE
feat: Tiny change to plugin.js to reduce the size of lodash on build

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Hookable from 'hookable'
-import { isArray, isObject } from 'lodash'
+import isArray from 'lodash/isArray';
+import isObject from 'lodash/isObject';
 
 const TOKEN_KEY = 'strapi_jwt'
 


### PR DESCRIPTION
I've changed the way the lodash functions are loaded to only include these 2 functions instead of the full lodash library.
This should reduce the build/vendor size of built nuxt applications when using this module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
This reduces the overall vendor size when building your application.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
