### PR TITLE
docs(): add graphql example with gql

### DIFF
--- a/docs/content/en/strapi.md
+++ b/docs/content/en/strapi.md
@@ -147,17 +147,50 @@ await this.$strapi.$products.delete(1)
 
 Performs an HTTP request to GraphQL API and returns its value
 
-```js
-await this.$strapi.graphql({
-  query: `
-    query {
-      products {
+<d-code-group>
+  <d-code-block label="Directly in methods" active>
+
+  ```js
+
+  await strapi.graphql({
+    query: `query {
+      restaurants {
+        id
         name
       }
-    }
-  `
-});
-```
+    }`
+  });
+  ```
+
+  </d-code-block>
+  <d-code-block label="With graphql-tag">
+
+  ```js{}[restaurants.js]
+  import gql from "graphql-tag";
+  
+  export function findRestaurants() {
+    const query = gql`
+      query {
+        restaurants {
+          id
+          name
+        }
+      }`;
+    return query.loc.source.body;  
+  }
+  ```
+
+  ```js
+  import { findRestaurants } from 'restaurants.js'
+
+  await strapi.graphql({
+    query: findRestaurants()
+  })
+  ```
+
+
+  </d-code-block>
+</d-code-group>
 
 ### `register(form)`
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs (a non-breaking change which add details about a feature)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

As mentioned in issue [#39](https://github.com/nuxt-community/strapi-module/issues/39), examples on how to properly import GraphQL queries were missing. So I updated the documentation as requested by Atinux ;)

Resolves: #39 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
