### PR TITLE
fix: broken links to Strapi API parameters page

### DIFF
--- a/docs/content/en/strapi.md
+++ b/docs/content/en/strapi.md
@@ -28,7 +28,7 @@ this.$strapi.user.avatar = ''
 
 - Returns `Promise`
 
-Get entries. Returns entries matching the query filters. You can read more about parameters [here](https://strapi.io/documentation/v3.x/content-api/parameters.html).
+Get entries. Returns entries matching the query filters. You can read more about parameters [here](https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#api-parameters).
 
 The second argument `params` is for query parameters:
 
@@ -75,7 +75,7 @@ await $strapi.$products.find({ 'categories.name': ['women', 'men'] })
 
 - Returns `Promise`
 
-Count entries. Returns the count of entries matching the query filters. You can read more about parameters [here](https://strapi.io/documentation/v3.x/content-api/parameters.html).
+Count entries. Returns the count of entries matching the query filters. You can read more about parameters [here](https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#api-parameters).
 
 ```js
 await this.$strapi.count('products', params)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

The link https://strapi.io/documentation/v3.x/content-api/parameters.html is broken, it redirects to a 404 page.
I updated it to https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#api-parameters which seems to be the equivalent new page.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

No tests since I just updated the documentation markdown.
