### PR TITLE
docs: Add GraphQL variables example (#154)

### DIFF
--- a/docs/pages/strapi.md
+++ b/docs/pages/strapi.md
@@ -155,12 +155,17 @@ Performs an HTTP request to GraphQL API and returns its value
   <code-block label="Directly in methods" active>
 
   ```js
+  const restaurantId = 4;
 
   await strapi.graphql({
     query: `query {
-      restaurants {
-        id
+      restaurant(id: ${restaurantId}) {
         name
+        phone
+        owners {
+          first
+          last
+        }
       }
     }`
   });
@@ -172,12 +177,16 @@ Performs an HTTP request to GraphQL API and returns its value
   ```js{}[restaurants.js]
   import gql from "graphql-tag";
 
-  export function findRestaurants() {
+  export function getRestaurant() {
     const query = gql`
-      query {
-        restaurants {
-          id
+      query getRestaurant($id: Int!) {
+        restaurant(id: $id) {
           name
+          phone
+          owners {
+            first
+            last
+          }
         }
       }`;
     return query.loc.source.body;
@@ -185,10 +194,15 @@ Performs an HTTP request to GraphQL API and returns its value
   ```
 
   ```js
-  import { findRestaurants } from 'restaurants.js'
+  import { getRestaurant } from 'restaurants.js'
 
+  const restaurantId = 4;
+    
   await this.$strapi.graphql({
-    query: findRestaurants()
+    query: getRestaurant(),
+    variables: {
+      id: restaurantId
+    }
   })
   ```
 


### PR DESCRIPTION
Resolves #154, documents the ability to provide and use GraphQL variables with the Strapi module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Update the documentation to show the Nuxt Strapi module's GraphQL being compatible with variables using a template literal as well as a GraphQL-tag.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
