### PR TITLE
feat : add publicationState if nuxt is in preview mode

### DIFF
--- a/docs/pages/strapi.md
+++ b/docs/pages/strapi.md
@@ -73,6 +73,10 @@ await $strapi.$products.find({ 'categories.name': ['women', 'men'], _limit: 200 
   </code-block>
 </code-group>
 
+<alert type="info">
+ `_publicationState=preview` is added if nuxt is in preview mode (https://nuxtjs.org/docs/features/live-preview/)
+</alert>
+
 > See the [Strapi endpoints](https://strapi.io/documentation/developer-docs/latest/developer-resources/content-api/content-api.html#endpoints).
 
 ### `count(entity, params)`

--- a/src/runtime/strapi.ts
+++ b/src/runtime/strapi.ts
@@ -20,6 +20,7 @@ export class Strapi extends Hookable {
   $cookies: NuxtCookies
   $http: NuxtHTTPInstance
   options: StrapiOptions
+  preview: boolean
 
   constructor (ctx, options: StrapiOptions) {
     super()
@@ -28,6 +29,7 @@ export class Strapi extends Hookable {
     const runtimeConfig = ctx.$config.strapi || {}
     this.$cookies = ctx.app.$cookies
     this.$http = ctx.$http.create({})
+    this.preview = ctx.query.preview
     this.options = options
 
     this.state = Vue.observable({ user: null })
@@ -130,10 +132,16 @@ export class Strapi extends Hookable {
   }
 
   find<T = any, E = string> (entity: E, searchParams?: NuxtStrapiQueryParams): Promise<T> {
+    searchParams = searchParams ?? {}
+    // eslint-disable-next-line dot-notation
+    searchParams['_publicationState'] = this.preview ? 'preview' : 'live'
     return this.$http.$get<T>(`/${entity}`, { searchParams })
   }
 
   count<T = any, E = string> (entity: E, searchParams?: NuxtStrapiQueryParams): Promise<T> {
+    searchParams = searchParams ?? {}
+    // eslint-disable-next-line dot-notation
+    searchParams['_publicationState'] = this.preview ? 'preview' : 'live'
     return this.$http.$get<T>(`/${entity}/count`, { searchParams })
   }
 


### PR DESCRIPTION
Add publicationState=preview in the strapi find URL, if nuxt is in preview mode.

This allow to get strapi draft contents in preview mode

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Add publicationState=preview in the strapi find URL, if nuxt is in preview mode.


## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
