### PR TITLE
fix: Hotfix publicRuntimeConfig vs Strapi default conf

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,7 @@ async function strapiModule (moduleOptions) {
 
   nuxt.options.publicRuntimeConfig = nuxt.options.publicRuntimeConfig || {}
   nuxt.options.publicRuntimeConfig.strapi = nuxt.options.publicRuntimeConfig.strapi || {}
-  nuxt.options.publicRuntimeConfig.strapi.url = options.url
+  nuxt.options.publicRuntimeConfig.strapi.url = nuxt.options.publicRuntimeConfig.strapi.url || options.url
 
   const runtimeDir = resolve(__dirname, 'runtime')
   nuxt.options.alias['~strapi'] = runtimeDir


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
The publicRuntimeConfig is not taken into account and is erased by Strapi default configuration object.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
