### PR TITLE
feat: add expiry date to strapi config

### DIFF
--- a/docs/pages/2.setup.md
+++ b/docs/pages/2.setup.md
@@ -45,7 +45,8 @@ Defaults:
 {
   url: process.env.STRAPI_URL || 'http://localhost:1337',
   prefix: '/api',
-  version: 'v4'
+  version: 'v4',
+  expires: 'session',
 }
 ```
 
@@ -64,6 +65,16 @@ Prefix of the Strapi server. Only used when version is `v4`.
 ### `version`
 
 Version of the Strapi server. Can only be `v4` or `v3`.
+
+### `expires`
+
+Defines when the authentication cookie expires.
+
+By default it is set to `session` which expires when the browser is closed.
+
+If the value is a string, it will be parsed using [ms](https://github.com/vercel/ms), for example: `expires: '31d'`
+
+A number can also be provided as milliseconds, ex. `expires: 31 * 24 * 3600 * 1000`
 
 ## Edge channel
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
     "defu": "^5.0.0",
-    "pathe": "^0.2.0"
+    "pathe": "^0.2.0",
+    "ms": "^2.1.3"
   },
   "devDependencies": {
     "@nuxt/schema": "npm:@nuxt/schema-edge@latest",

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,5 @@
 import defu from 'defu'
+import ms from 'ms'
 import { resolve } from 'pathe'
 import { defineNuxtModule, addPlugin } from '@nuxt/kit'
 import type { StrapiOptions } from './types'
@@ -15,7 +16,8 @@ export default defineNuxtModule<StrapiOptions>({
   defaults: {
     url: process.env.STRAPI_URL || 'http://localhost:1337',
     prefix: '/api',
-    version: 'v4'
+    version: 'v4',
+    expires: 'session',
   },
   setup (options: StrapiOptions, nuxt) {
     // Make sure url is set
@@ -23,11 +25,17 @@ export default defineNuxtModule<StrapiOptions>({
       throw new Error('Missing `STRAPI_URL` in `.env`')
     }
 
+    // Convert expires time string to ms
+    if (typeof options.expires === 'string' && options.expires !== 'session') {
+      options.expires = ms(options.expires)
+    }
+
     // Default runtimeConfig
     nuxt.options.publicRuntimeConfig.strapi = defu(nuxt.options.publicRuntimeConfig.strapi, {
       url: options.url,
       prefix: options.prefix,
-      version: options.version
+      version: options.version,
+      expires: options.expires
     })
 
     // Transpile runtime

--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -1,4 +1,8 @@
-import { useCookie, useNuxtApp } from '#app'
+import { useCookie, useNuxtApp, useRuntimeConfig } from '#app'
+
+const getExpirationDate = (ms: number) => {
+  return new Date(Date.now() + ms)
+}
 
 export const useStrapiToken = () => {
   const nuxtApp = useNuxtApp()
@@ -8,7 +12,10 @@ export const useStrapiToken = () => {
     return nuxtApp._cookies.strapi_jwt
   }
 
-  const cookie = useCookie<string | null>('strapi_jwt')
+  const config = useRuntimeConfig()
+  const expires = config.strapi.expires === 'session' ? undefined : getExpirationDate(config.strapi.expires)
+
+  const cookie = useCookie<string | null>('strapi_jwt', { expires })
   nuxtApp._cookies.strapi_jwt = cookie
   return cookie
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -543,6 +543,14 @@ export interface StrapiOptions {
    * @example 'v3'
    */
   version?: StrapiOptionsVersion
+  
+  /**
+   * Session Expiry
+   * @default 'session'
+   * @type string
+   * @example '31d'
+   */
+   expires?: 'session' | string | number
 }
 
 export type StrapiUser = object | null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
As this is my first open source pr, I hope I did everything well :)

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Currently the strapi token is saved as a session cookie which expires as soon as the browser is closed.

Back in v0, there was a [config option](https://strapi-v0.nuxtjs.org/options#expires) which allowed to set the expires property.
With this pull request I have added such a feature.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [-] I have added tests to cover my changes (if not applicable, please state why)