### PR TITLE
feat: custom payload properties for registration

### DIFF
--- a/docs/pages/3.usage.md
+++ b/docs/pages/3.usage.md
@@ -32,8 +32,8 @@ On `login`, `register`, `resetPassword` and `authenticateProvider` methods, the 
 Submit the user's identifier and password credentials for authentication. Sets [`user`](/usage#useStrapiUser) and [`token`](/usage#useStrapiToken).
 
 - **Arguments:**
-  - data: [`StrapiAuthenticationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L553)
-- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L548)
+  - data: [`StrapiAuthenticationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L529)
+- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L524)
 
 ```vue [pages/login.vue]
 <script setup lang="ts">
@@ -76,8 +76,8 @@ Creates a new user in the database with a default role as `Authenticated`.
 Custom user fields, for example a phone number, can be added as well.
 
 - **Arguments:**
-  - data: [`StrapiRegistrationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L558)
-- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L548)
+  - data: [`StrapiRegistrationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L534)
+- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L524)
 
 ```vue [pages/register.vue]
 <script setup lang="ts">
@@ -101,7 +101,7 @@ const onSubmit = async () => {
 This action sends an email to a user with the link to your own reset password page. The link will be enriched with the url param code that is needed for the [`resetPassword`](/usage#resetPassword).
 
 - **Arguments:**
-  - data: [`StrapiForgotPasswordData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L564)
+  - data: [`StrapiForgotPasswordData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L541)
 - **Returns:** `Promise<void>`
 
 ```vue [pages/forgot.vue]
@@ -123,8 +123,8 @@ const onSubmit = async () => {
 This action will update the user password. Sets [`user`](/usage#useStrapiUser) and [`token`](/usage#useStrapiToken).
 
 - **Arguments:**
-  - data: [`StrapiResetPasswordData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L568)
-- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L558)
+  - data: [`StrapiResetPasswordData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L545)
+- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L524)
 
 ```vue [pages/reset.vue]
 <script setup lang="ts">
@@ -148,7 +148,7 @@ const onSubmit = async () => {
 This action will re-send the confirmation sent after [`registration`](/usage#register).
 
 - **Arguments:**
-  - data: [`StrapiEmailConfirmationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L574)
+  - data: [`StrapiEmailConfirmationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L551)
 - **Returns:** `Promise<void>`
 
 ```vue
@@ -170,7 +170,7 @@ const onSubmit = async () => {
 Return the correct URL to authenticate with provider.
 
 - **Arguments:**
-  - provider: [`StrapiAuthProvider`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L503)
+  - provider: [`StrapiAuthProvider`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L505)
 - **Returns:** `string`
 
 ```vue [pages/login.vue]
@@ -188,9 +188,9 @@ const onClick = () => {
 Authenticate user with external provider. Sets [`user`](/usage#useStrapiUser) and [`token`](/usage#useStrapiToken).
 
 - **Arguments:**
-  - provider: [`StrapiAuthProvider`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L503)
+  - provider: [`StrapiAuthProvider`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L505)
   - access_token: `string`
-- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L558)
+- **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L524)
 
 ```vue [pages/auth/[provider]/callback.vue]
 <script setup lang="ts">
@@ -227,7 +227,7 @@ Those composables are available for both `v3` and `v4` versions. Define version 
 
 <alert type="info">
 
-All examples below are demonstrated with `useStrapi4()`. Note that `useStrapi3()` exposes the same methods. Check out specific types for [v3](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v3.ts) and [v4](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v4.ts).
+All examples below are demonstrated with `useStrapi4()`. Note that `useStrapi3()` exposes the same methods. Check out specific types for [v3](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v3.d.ts) and [v4](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts).
 
 </alert>
 
@@ -239,7 +239,7 @@ Get entries. Returns entries matching the query filters (see [parameters](https:
 
 - **Arguments:**
   - contentType: `string`
-  - params?: [`Strapi4RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v4.ts#L24)
+  - params?: [`Strapi4RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts#L24)
 - **Returns:** `Promise<T>`
 
 ```vue
@@ -262,7 +262,7 @@ Returns an entry by `id`.
 - **Arguments:**
   - contentType: `string`
   - id: `string | number`
-  - params?: [`Strapi4RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v4.ts#L24)
+  - params?: [`Strapi4RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts#L24)
 - **Returns:** `Promise<T>`
 
 ```vue
@@ -366,7 +366,7 @@ Available only for `v3` as Strapi v4 can do the same thing with the [Pagination 
 
 - **Arguments:**
   - contentType: `string`
-  - params?: [`Strapi3RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v3.ts#L9)
+  - params?: [`Strapi3RequestParams`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v3.d.ts#L9)
 - **Returns:** `Promise<number>`
 
 ```vue
@@ -419,7 +419,7 @@ This composable is a wrapper around [Nuxt 3 `$fetch` helper](https://v3.nuxtjs.o
 
 - **Arguments:**
   - url: `string`
-  - fetchOptions?: [`FetchOptions`](https://github.com/unjs/ohmyfetch/blob/main/src/fetch.ts#L14)
+  - fetchOptions?: [`FetchOptions`](https://github.com/unjs/ohmyfetch/blob/main/src/fetch.ts#L26)
 - **Returns:** `Promise<number>`
 
 ```vue

--- a/docs/pages/3.usage.md
+++ b/docs/pages/3.usage.md
@@ -73,7 +73,7 @@ const onClick = () => {
 
 Creates a new user in the database with a default role as `Authenticated`.
 
-Custom user fields, for example a phone number, can be added as well.
+Custom user fields, if added to the content type, e.g. `phoneNumber`, can be added to the payload as well.
 
 - **Arguments:**
   - data: [`StrapiRegistrationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/index.d.ts#L534)

--- a/docs/pages/3.usage.md
+++ b/docs/pages/3.usage.md
@@ -73,6 +73,8 @@ const onClick = () => {
 
 Creates a new user in the database with a default role as `Authenticated`.
 
+Custom user fields, for example a phone number, can be added as well.
+
 - **Arguments:**
   - data: [`StrapiRegistrationData`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L558)
 - **Returns:** [`Promise<StrapiAuthenticationResponse>`](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/index.ts#L548)
@@ -84,7 +86,7 @@ const router = useRouter()
 
 const onSubmit = async () => {
   try {
-    await register({ identifier: '', password: '' })
+    await register({ username: '', email: '', password: '', phoneNumber: '' })
 
     router.push('/authenticated-page')
   } catch (e) {}

--- a/docs/pages/4.advanced.md
+++ b/docs/pages/4.advanced.md
@@ -80,7 +80,7 @@ export default defineNuxtPlugin((nuxt) => {
 })
 ```
 
-> Check out the [Strapi4Error](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v4.ts#L3) type.
+> Check out the [Strapi4Error](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v4.d.ts#L3) type.
 
 ### `v3`
 
@@ -104,7 +104,7 @@ export default defineNuxtPlugin((nuxt) => {
 })
 ```
 
-> Check out the [Strapi3Error](https://github.com/nuxt-community/strapi-module/blob/dev/src/types/v3.ts#L3) type.
+> Check out the [Strapi3Error](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/types/v3.d.ts#L3) type.
 
 ## Override Strapi `/users/me` route
 
@@ -168,4 +168,4 @@ async function onSubmit () {
 </script>
 ```
 
-> Note that you have to use the `client` because `create` and `update` methods sends the [body inside `data`](https://github.com/nuxt-community/strapi-module/blob/dev/src/composables/useStrapi4.ts#L52).
+> Note that you have to use the `client` because `create` and `update` methods sends the [body inside `data`](https://github.com/nuxt-community/strapi-module/blob/dev/src/runtime/composables/useStrapi4.ts#L64).

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -513,8 +513,10 @@ export type StrapiAuthProvider =
   | 'instagram'
   | 'vk'
   | 'linkedin'
+  | 'cas'
   | 'reddit'
   | 'auth0'
+  | string
 
 
 export type StrapiUser = object | null
@@ -533,6 +535,7 @@ export interface StrapiRegistrationData {
   username?: string
   email: string
   password: string
+  [field: string]: string | number | boolean | object | Array<string | number | boolean | object>
 }
 
 export interface StrapiForgotPasswordData {


### PR DESCRIPTION
PR to implement the feature proposed in issue #189.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Added the possibility to add custom user fields to the registration payload.

`[field: string]: string | number | boolean | object | Array<string | number | boolean | object>`

The types `string`, `number`, `boolean` and `object` together with the same types as an array should cover all possible fields in Strapi.

I also checked if the register endpoint can somehow handle FormData (spoiler, it doesn't) to add a profile picture on registration. But since this would be a custom change to a Strapi controller, it's not really needed here.

Furthermore I added the `cas` authentication provider which I found in [this tablist](https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#setting-up-the-provider-examples) and the possibility to add a custom provider string, as it is possible to [add custom providers](https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#adding-a-new-provider-to-your-project) to Strapi.

Finally, I went through all pages of the documentation and just verified / corrected links which point to a certain line of code. I also corrected the register example which used `identifier` & `password` as payload properties and added the `phoneNumber` property as an example.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
