### PR TITLE
chore: add array types to NuxtStrapiQueryParams for more complex payloads

### DIFF
--- a/docs/pages/usage.md
+++ b/docs/pages/usage.md
@@ -17,8 +17,10 @@ await this.$strapi.login({ identifier: '', password: '' })
 
 ### Register
 
+Custom user fields, if added to the entity, can be sent with the registration payload as well. For example `phoneNumber`.
+
 ```js
-await this.$strapi.register({ email: '', username: '', password: '' })
+await this.$strapi.register({ email: '', username: '', password: '', phoneNumber: '' })
 ```
 
 ### Logout

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -25,9 +25,10 @@ export interface NuxtStrapiGraphQLParams {
 }
 
 export interface NuxtStrapiRegistrationData {
-  username: string;
+  username?: string;
   email: string;
   password: string;
+  [key: string]: string | number | boolean | Array<string | number | boolean>;
 }
 
 export interface NuxtStrapiLoginData {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -4,7 +4,7 @@ export type NuxtStrapiUser = Record<string, any>
 
 export type NuxtStrapiQueryParams =
   string |
-  {[key: string]: string | number | boolean} |
+  {[key: string]: string | number | boolean | Array<string | number | boolean>} |
   Array<Array<string | number | boolean>> |
   URLSearchParams
 


### PR DESCRIPTION
Hello

A PR as discussed in issue #161 & #189

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

I have added `Array<string | number | boolean>` to the already existing [NuxtStrapiQueryParams type](https://github.com/nuxt-community/strapi-module/blob/v0-support/src/runtime/types.ts#L5).

This is to ensure that update and create requests can handle more complex data, such as an array of user ids.

Furthermore, I have added custom properties to the registration type and made the username optional.
Strapi 3 also [supports these custom properties](https://github.com/strapi/strapi/blob/releases/v3.6.9/packages/strapi-plugin-users-permissions/controllers/Auth.js#L403). Only the ciritcal properties `['confirmed', 'confirmationToken', 'resetPasswordToken']` are omitted.

This is to reflect the changes made in v1 of this module. (#218)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Updated the registration documentation to reflect the new custom properties.
