### PR TITLE
feat(module): support server-specific runtime configuration

### DIFF
--- a/docs/pages/4.advanced.md
+++ b/docs/pages/4.advanced.md
@@ -3,6 +3,31 @@ title: Advanced
 description: 'Real-life advanced usages of the strapi module.'
 ---
 
+## Server-Specific Configuration
+
+You can apply configuration based on whether a request is processed on the browser or server by using Nuxt [runtimeConfig](https://v3.nuxtjs.org/guide/features/runtime-config). Options provided directly over `runtimeConfig` field will override options provided in the `strapi` field of Nuxt configuration.
+
+```ts
+export default defineNuxtConfig({
+  // ...
+  runtimeConfig: {
+    strapi: { // nuxt/strapi options available server-side
+      url: 'http://example-strapi-instance:1337'
+    },
+    public: {
+      strapi: { // nuxt/strapi options available client-side
+        url: 'https://strapi.example.com'
+      }
+    }
+  },
+  // nuxt/strapi options available on both client and server
+  strapi: {
+    prefix: '/api'
+  }
+  // ...
+})
+```
+
 ## Async data
 
 To take full advantage of server-side rendering, you can use Nuxt [useAsyncData](https://v3.nuxtjs.org/docs/usage/data-fetching#useasyncdata) composable:

--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -5,6 +5,17 @@ export default defineNuxtConfig({
   buildModules: [
     module
   ],
+  // example of separate client/server URLs
+  /* runtimeConfig: {
+    strapi: {
+      url: 'http://localhost:1337'
+    },
+    public: {
+      strapi: {
+        url: 'http://content:1337'
+      }
+    }
+  }, */
   strapi: {
     url: 'http://localhost:1337'
   }

--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -7,13 +7,9 @@ export default defineNuxtConfig({
   ],
   // example of separate client/server URLs
   /* runtimeConfig: {
-    strapi: {
-      url: 'http://localhost:1337'
-    },
+    strapi: { url: 'http://localhost:1337' },
     public: {
-      strapi: {
-        url: 'http://content:1337'
-      }
+      strapi: { url: 'http://content:1337' }
     }
   }, */
   strapi: {

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -3,7 +3,9 @@
     <h1>@nuxtjs/strapi</h1>
 
     <h2>Url</h2>
-    <pre>{{ url }}</pre>
+    <client-only>
+      <pre>{{ url }}</pre>
+    </client-only>
     <h2>Version</h2>
     <pre>{{ version }}</pre>
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -64,6 +64,12 @@ export default defineNuxtModule<ModuleOptions>({
       version: options.version,
       cookie: options.cookie
     })
+    nuxt.options.runtimeConfig.strapi = defu(nuxt.options.runtimeConfig.strapi, {
+      url: options.url,
+      prefix: options.prefix,
+      version: options.version,
+      cookie: options.cookie
+    })
 
     // Transpile runtime
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))

--- a/src/runtime/composables/useStrapiGraphQL.ts
+++ b/src/runtime/composables/useStrapiGraphQL.ts
@@ -3,7 +3,7 @@ import { useStrapiClient } from './useStrapiClient'
 
 export const useStrapiGraphQL = () => {
   const client = useStrapiClient()
-  const config = useRuntimeConfig().public
+  const config = useRuntimeConfig()
 
   return <T> (query: string): Promise<T> => {
     return client('/graphql', { method: 'POST', body: { query }, baseURL: config.strapi.url })

--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -2,7 +2,7 @@ import { useCookie, useNuxtApp, useRuntimeConfig } from '#app'
 
 export const useStrapiToken = () => {
   const nuxtApp = useNuxtApp()
-  const config = useRuntimeConfig().public
+  const config = useRuntimeConfig()
 
   nuxtApp._cookies = nuxtApp._cookies || {}
   if (nuxtApp._cookies.strapi_jwt) {

--- a/src/runtime/composables/useStrapiUrl.ts
+++ b/src/runtime/composables/useStrapiUrl.ts
@@ -1,7 +1,7 @@
 import { useRuntimeConfig } from '#app'
 
 export const useStrapiUrl = (): string => {
-  const config = useRuntimeConfig().public
+  const config = useRuntimeConfig()
   const version = config.strapi.version
   return version === 'v3' ? config.strapi.url : `${config.strapi.url}${config.strapi.prefix}`
 }

--- a/src/runtime/composables/useStrapiVersion.ts
+++ b/src/runtime/composables/useStrapiVersion.ts
@@ -1,6 +1,6 @@
 import { useRuntimeConfig } from '#app'
 
 export const useStrapiVersion = (): string => {
-  const config = useRuntimeConfig().public
+  const config = useRuntimeConfig()
   return config.strapi.version
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This allows server-side requests to make use of a separate URL by making full use of runtimeConfig in Nuxt. For instance, I may access a locally-running Strapi instance server-side at http://strapi-instance:1337 while client-side I would use https://strapi.example.com.

This is a functionality that has been very helpful in containerized environments, provided as an [option by modules like nuxt/axios in Nuxt2](https://axios.nuxtjs.org/options#browserbaseurl).

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I was unable to find tests within the repository. 