### PR TITLE
Added missing header preventing successful graphql requests

### DIFF
--- a/src/runtime/composables/useStrapiGraphQL.ts
+++ b/src/runtime/composables/useStrapiGraphQL.ts
@@ -6,6 +6,13 @@ export const useStrapiGraphQL = () => {
   const config = useRuntimeConfig().public
 
   return <T> (query: string): Promise<T> => {
-    return client('/graphql', { method: 'POST', body: { query }, baseURL: config.strapi.url })
+    return client('/graphql', {
+      method: 'POST',
+      body: { query },
+      headers: {
+        accept: 'application/json'
+      },
+      baseURL: config.strapi.url
+    })
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

I added an "Accept" request header to the `useStrapiGraphQL` composable so that I can receive the response. Previously I would receive an error that appeared to come from "ohmyfetch" that the POST body was missing.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
