### PR TITLE
Support for imported graphql files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.0.0-rc.1",
     "defu": "^6.0.0",
+    "graphql": "^16.5.0",
     "pathe": "^0.2.0",
     "qs": "^6.10.3"
   },

--- a/src/runtime/composables/useStrapiGraphQL.ts
+++ b/src/runtime/composables/useStrapiGraphQL.ts
@@ -1,14 +1,19 @@
 import { useRuntimeConfig } from '#app'
+import { print } from 'graphql'
+import type { DocumentNode } from 'graphql'
 import { useStrapiClient } from './useStrapiClient'
 
 export const useStrapiGraphQL = () => {
   const client = useStrapiClient()
   const config = useRuntimeConfig().public
 
-  return <T> (query: string): Promise<T> => {
+  return <T> (query: string|DocumentNode, variables?: { [key: string]: unknown }): Promise<T> => {
     return client('/graphql', {
       method: 'POST',
-      body: { query },
+      body: {
+        query: typeof query === 'string' ? query : print(query),
+        variables
+      },
       headers: {
         accept: 'application/json'
       },

--- a/src/runtime/composables/useStrapiGraphQL.ts
+++ b/src/runtime/composables/useStrapiGraphQL.ts
@@ -6,6 +6,13 @@ export const useStrapiGraphQL = () => {
   const config = useRuntimeConfig().public
 
   return <T> (query: string): Promise<T> => {
-    return client('/graphql', { method: 'POST', body: { query }, baseURL: config.strapi.url })
+    return client('/graphql', {
+      method: 'POST',
+      body: { query },
+      headers: {
+        accept: 'application/json'
+      },
+      baseURL: config.strapi.url
+    })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3223,6 +3223,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+graphql@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
+  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
+
 gzip-size@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-7.0.0.tgz#9f9644251f15bc78460fccef4055ae5a5562ac60"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Adds support for queries that are imported from a file. For instance, if someone used [@rollup/plugin-graphql](https://www.npmjs.com/package/@rollup/plugin-graphql) with Vite to import a GraphQL file, the imported file would be a `DocumentNode` and not the expected query by the Nuxt/Strapi module today.

Since variables are defined on the query and can't be passed directly when using a file, an optional variables argument is added to the `useStrapiGraphQL` composable so that those arguments can be passed.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
