### PR TITLE
fix(docs): renamed buildModules to modules

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -18,11 +18,11 @@ Add `@nuxtjs/strapi` dev dependency to your project:
   ```
 ::
 
-Then, add `@nuxtjs/strapi` to the [`buildModules`](https://v3.nuxtjs.org/docs/directory-structure/nuxt.config#buildmodules) section of your Nuxt configuration:
+Then, add `@nuxtjs/strapi` to the [`modules`](https://v3.nuxtjs.org/api/configuration/nuxt.config#modules) section of your Nuxt configuration:
 
 ```ts [nuxt.config.js|ts]
 export default {
-  buildModules: ['@nuxtjs/strapi'],
+  modules: ['@nuxtjs/strapi'],
   strapi: {
     // Options
   }


### PR DESCRIPTION
buildModules was deprecated in Nuxt 3

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
