### PR TITLE
feat: make cookie name configurable

### DIFF
--- a/docs/content/2.setup.md
+++ b/docs/content/2.setup.md
@@ -39,6 +39,7 @@ Defaults:
   prefix: '/api',
   version: 'v4',
   cookie: {},
+  cookieName: 'strapi_jwt'
 }
 ```
 
@@ -60,9 +61,13 @@ Version of the Strapi server. Can only be `v4` or `v3`.
 
 ### `cookie`
 
-Cookie options of the Strapi token cookie `strapi_jwt`.
+Cookie options of the Strapi token cookie.
 
 > All cookie options can be found in the [Nuxt documentation](https://v3.nuxtjs.org/docs/usage/cookies/#options)
+
+### `cookieName`
+
+Cookie name of the Strapi token cookie
 
 ### `auth.populate`
 

--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -13,6 +13,6 @@ export default defineNuxtConfig({
     }
   }, */
   strapi: {
-    url: 'http://localhost:1337',
+    url: 'http://localhost:1337'
   }
 })

--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -13,6 +13,6 @@ export default defineNuxtConfig({
     }
   }, */
   strapi: {
-    url: 'http://localhost:1337'
+    url: 'http://localhost:1337',
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,7 +49,7 @@ export interface ModuleOptions {
   auth?: AuthOptions
   /**
    * Strapi Cookie Name
-   * @default "strapi_jwt"
+   * @default 'strapi_jwt'
    * @type string
   */
   cookieName?: string
@@ -84,14 +84,16 @@ export default defineNuxtModule<ModuleOptions>({
       prefix: options.prefix,
       version: options.version,
       cookie: options.cookie,
-      auth: options.auth
+      auth: options.auth,
+      cookieName: options.cookieName
     })
     nuxt.options.runtimeConfig.strapi = defu(nuxt.options.runtimeConfig.strapi, {
       url: options.url,
       prefix: options.prefix,
       version: options.version,
       cookie: options.cookie,
-      auth: options.auth
+      auth: options.auth,
+      cookieName: options.cookieName
     })
 
     // Transpile runtime

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,6 +47,12 @@ export interface ModuleOptions {
    * @example { populate: ['profile', 'teams'] }
   */
   auth?: AuthOptions
+  /**
+   * Strapi Cookie Name
+   * @default "strapi_jwt"
+   * @type string
+  */
+  cookieName?: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -63,7 +69,8 @@ export default defineNuxtModule<ModuleOptions>({
     prefix: '/api',
     version: 'v4',
     cookie: {},
-    auth: {}
+    auth: {},
+    cookieName: 'strapi_jwt'
   },
   setup (options, nuxt) {
     // Make sure url is set

--- a/src/runtime/composables/useStrapiToken.ts
+++ b/src/runtime/composables/useStrapiToken.ts
@@ -5,11 +5,11 @@ export const useStrapiToken = () => {
   const config = useRuntimeConfig()
 
   nuxtApp._cookies = nuxtApp._cookies || {}
-  if (nuxtApp._cookies.strapi_jwt) {
-    return nuxtApp._cookies.strapi_jwt
+  if (nuxtApp._cookies[config.strapi.cookieName]) {
+    return nuxtApp._cookies[config.strapi.cookieName]
   }
 
-  const cookie = useCookie<string | null>('strapi_jwt', config.strapi.cookie)
-  nuxtApp._cookies.strapi_jwt = cookie
+  const cookie = useCookie<string | null>(config.strapi.cookieName, config.strapi.cookie)
+  nuxtApp._cookies[config.strapi.cookieName] = cookie
   return cookie
 }


### PR DESCRIPTION
With this PR #262 can be closed, now the cookie name is configurable. Default is `strapi_jwt`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
